### PR TITLE
Fixed trailing character in PID setup menu

### DIFF
--- a/Open-ArdBir/LCD20x4_ENG.h
+++ b/Open-ArdBir/LCD20x4_ENG.h
@@ -243,6 +243,10 @@ void PidSet(int pidSet, byte i){
     if (pidSet == 0) lcd.print(F("  Electric"));
     else             lcd.print(F("       Gas"));
   } else {
+    // clear that pesky trailing "c" or "s" from the previous menu
+    lcd.setCursor(19, 2);
+    LCDSpace(1);
+    
     lcd.setCursor(13, 2);
     LCDSpace(1);
 


### PR DESCRIPTION
Fixed trailing character in PID -- PWM setup menu for English language.

The trailing “c” from the word “Electric”, or the trailing “s” from the word “Gas” wasn’t being cleared in the PID setup menus. 

E.g. You can see the problem in this youtube video: https://youtu.be/C_HDUacxeNs?t=31s
